### PR TITLE
Make the profile README portfolio-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,101 @@
-# 👋 Hey there! I'm Agastya
+<p align="center">
+  <a href="https://agstya.github.io/" aria-label="Visit Agastya Kommanamanchi's portfolio">
+    <img src="https://agstya.github.io/assets/images/og-card.png" width="100%" alt="Agastya Kommanamanchi — Forward-Deployed AI Engineering Leader. AI, Data, Cloud.">
+  </a>
+</p>
 
-## 🤖 About Me
-I'm passionate about **Agentic AI Engineering & Architecture**, exploring the cutting edge of autonomous AI systems and multi-agent frameworks.
+<h1 align="center">Building AI systems that move from ambition to adoption.</h1>
 
-## 👀 What I'm Interested In
-- 🔬 Building intelligent agent systems
-- 🏗️ AI architecture and design patterns
-- 🚀 Scalable AI solutions
-- 🌐 Open source agentic frameworks
+<p align="center">
+  Forward-Deployed AI Engineer at Deloitte · Enterprise Solutions Architect · Builder
+  <br>
+  <strong>10+ years turning complex AI, data, and cloud opportunities into secure production platforms.</strong>
+</p>
 
-## 🤝 Collaboration
-I'm actively looking to collaborate on **open source agentic frameworks**! If you're working on exciting AI projects, let's connect and build something amazing together.
+<p align="center">
+  <a href="https://agstya.github.io/"><img src="https://img.shields.io/badge/ENTER_THE_PORTFOLIO-00D9FF?style=for-the-badge&logo=googlechrome&logoColor=00111F" alt="Enter the portfolio"></a>
+  <a href="https://www.linkedin.com/in/agastya-kommanamanchi/"><img src="https://img.shields.io/badge/CONNECT_ON_LINKEDIN-7257FF?style=for-the-badge&logo=linkedin&logoColor=white" alt="Connect on LinkedIn"></a>
+</p>
 
-## 📫 Get In Touch
-- 💼 **LinkedIn**: [Agastya Kommanamanchi](https://www.linkedin.com/in/agastya-kommanamanchi)
-- 📧 **Email**: agastya@utexas.edu
+<p align="center"><sub>↑ The cover and portfolio button both open the complete interactive experience.</sub></p>
 
 ---
 
-<!---
-agstya/agstya is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+## Where strategy meets the build
+
+I lead production AI, data, and cloud initiatives from opportunity shaping and executive alignment through architecture, engineering, and adoption. My work spans **agentic systems, identity-aware retrieval, enterprise copilots, cloud data platforms, and responsible AI delivery**—especially in regulated environments where reliability matters.
+
+> I enjoy the hard middle: balancing value, scalability, security, and delivery risk while keeping teams focused on measurable outcomes.
+
+### Impact in production
+
+| **95%+** | **40%** | **25%** | **$1.2M** |
+| :---: | :---: | :---: | :---: |
+| AI task success | lower latency | lower inference cost | annual cloud savings |
+
+| **$4.5M** | **50M+** | **10TB** | **200+** |
+| :---: | :---: | :---: | :---: |
+| recovery supported | users served | telemetry processed daily | engineers enabled |
+
+## Selected systems
+
+| System | What shipped | Measured outcome |
+| --- | --- | --- |
+| **Enterprise underwriting intelligence** | Secure agentic assistants with identity-aware retrieval, evaluation, and production controls | **95%+** task success · **40%** lower latency · **25%** lower inference cost |
+| **Customer 360 intelligence platform** | Real-time and batch customer, meter, and operational data on AWS with embedded predictive outputs | **12%** better retention · **$4.5M** recovery supported |
+| **Multi-cloud FinOps platform** | Cost visibility, anomaly detection, and automated infrastructure controls across AWS and Google Cloud | **200+** engineers enabled · **$1.2M** annual savings |
+| **Behavioral intelligence at scale** | Recommendation, telemetry, and experimentation systems processing more than 10TB daily | **50M+** users · **25%** longer sessions · **14%** higher CTR |
+
+<p align="right"><a href="https://agstya.github.io/#work"><strong>Explore the full case studies →</strong></a></p>
+
+## Systems-level toolkit
+
+**AI engineering**
+
+![RAG](https://img.shields.io/badge/RAG-0A1020?style=flat-square&logoColor=white) ![AI Agents](https://img.shields.io/badge/AI_AGENTS-0A1020?style=flat-square&logoColor=white) ![Context Engineering](https://img.shields.io/badge/CONTEXT_ENGINEERING-0A1020?style=flat-square&logoColor=white) ![Evaluation](https://img.shields.io/badge/EVALUATION-0A1020?style=flat-square&logoColor=white) ![Guardrails](https://img.shields.io/badge/GUARDRAILS-0A1020?style=flat-square&logoColor=white) ![MCP](https://img.shields.io/badge/MCP-0A1020?style=flat-square&logoColor=white)
+
+**Platforms & data**
+
+![AWS](https://img.shields.io/badge/AWS-232F3E?style=flat-square&logo=amazonwebservices&logoColor=white) ![Google Cloud](https://img.shields.io/badge/GOOGLE_CLOUD-4285F4?style=flat-square&logo=googlecloud&logoColor=white) ![Databricks](https://img.shields.io/badge/DATABRICKS-FF3621?style=flat-square&logo=databricks&logoColor=white) ![Snowflake](https://img.shields.io/badge/SNOWFLAKE-29B5E8?style=flat-square&logo=snowflake&logoColor=white) ![Apache Spark](https://img.shields.io/badge/APACHE_SPARK-E25A1C?style=flat-square&logo=apachespark&logoColor=white) ![Kubernetes](https://img.shields.io/badge/KUBERNETES-326CE5?style=flat-square&logo=kubernetes&logoColor=white) ![Terraform](https://img.shields.io/badge/TERRAFORM-844FBA?style=flat-square&logo=terraform&logoColor=white)
+
+**Architecture & delivery**
+
+`Microservices` · `Event-driven systems` · `APIs` · `MLOps / LLMOps` · `Security & governance` · `Solution shaping` · `Executive alignment`
+
+## Granted patent
+
+**[US 12,518,057 B2 — System and method for a generative artificial intelligence model gateway](https://patents.google.com/patent/US12518057B2/en)**<br>
+A secure enterprise AI gateway for sensitive-data evaluation, governed access to approved language models, and managed interaction with model outputs. Granted January 6, 2026.
+
+<p align="center">
+  <a href="https://agstya.github.io/#credentials">Credentials</a>
+  &nbsp;·&nbsp;
+  <a href="https://agstya.github.io/#insights">Writing & visualizations</a>
+  &nbsp;·&nbsp;
+  <a href="https://agstya.github.io/#open-source">Open source lab</a>
+  &nbsp;·&nbsp;
+  <a href="https://agstya.github.io/#contact">Contact</a>
+</p>
+
+---
+
+<h2 align="center">Have an ambitious AI problem?</h2>
+
+<p align="center"><strong>Let's turn it into a system that ships.</strong></p>
+
+<p align="center">
+  <a href="https://agstya.github.io/"><img src="https://img.shields.io/badge/EXPLORE_AGSTYA.GITHUB.IO-00D9FF?style=for-the-badge&logo=githubpages&logoColor=00111F" alt="Explore agstya.github.io"></a>
+  <a href="mailto:kommanamanchi.agastya@gmail.com"><img src="https://img.shields.io/badge/START_A_CONVERSATION-7257FF?style=for-the-badge&logo=gmail&logoColor=white" alt="Start a conversation by email"></a>
+</p>
+
+<p align="center">
+  <a href="https://www.linkedin.com/in/agastya-kommanamanchi/">LinkedIn</a>
+  &nbsp;·&nbsp;
+  <a href="https://dev.to/agastya_kommanamanchi_d4f">DEV</a>
+  &nbsp;·&nbsp;
+  <a href="https://public.tableau.com/app/profile/agastya.kommanamanchi">Tableau</a>
+  &nbsp;·&nbsp;
+  <a href="https://www.credly.com/users/agastya/badges/credly">Credly</a>
+</p>
+
+<p align="center"><sub>Designed for clarity. Engineered for impact.</sub></p>


### PR DESCRIPTION
## What changed

- turns the website's visual identity into a fully clickable README hero
- makes `https://agstya.github.io/` the primary call to action at the top and bottom
- adds concise production-impact metrics and selected case studies
- organizes the AI, data, cloud, architecture, and delivery toolkit into a clean scan path
- highlights the granted GenAI gateway patent and refreshed contact links

## Why

The previous profile README undersold the depth of the portfolio and buried the user's strongest destination. This redesign makes the GitHub profile feel like the front door to the portfolio while still giving visitors enough proof of impact to keep reading.

## Validation

- rendered through GitHub's GFM Markdown API
- verified the hero artwork, portfolio, patent, DEV, Tableau, Credly, and badge destinations
- ran `git diff --check`
